### PR TITLE
The context parameter in from_db_value is being deprecated

### DIFF
--- a/konst/models/fields.py
+++ b/konst/models/fields.py
@@ -30,7 +30,7 @@ class ConstantChoiceFieldMixin(object):
             return value.v
         return value
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, *args):
         # print "from_db_value: {}: {}".format(type(value), value)
         if value is None:
             return value


### PR DESCRIPTION
With the current version of `django-konst` the following deprecation warning is observed:
```
site-packages/django/db/models/sql/compiler.py:1030: RemovedInDjango30Warning: Remove the context parameter from ConstantChoiceCharField.from_db_value(). Support for it will be removed in Django 3.0.
```

This change avoids impact from the deprecation of the `context` parameter in `ConstantChoiceCharField.from_db_value()` in a way that is suitable for versions of Django that still rely on it.