### PR TITLE
Changes for Django 3.2 and 4.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
         environment:
           - TOXENV=checkqa
           - UPLOAD_COVERAGE=0
+
   py36dj22:
     <<: *common
     docker:
@@ -54,12 +55,37 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV=py36-dj31
+  py36dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj32
+  py36dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj40
+  py36dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj41
+  py36dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV=py36-dj42
   py36djmaster:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV=py36-djmaster
+
   py37dj22:
     <<: *common
     docker:
@@ -78,12 +104,37 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV=py37-dj31
+  py37dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj32
+  py37dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj40
+  py37dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj41
+  py37dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV=py37-dj42
   py37djmaster:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV=py37-djmaster
+
   py38dj22:
     <<: *common
     docker:
@@ -102,12 +153,37 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV=py38-dj31
+  py38dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV=py38-dj32
+  py38dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV=py38-dj40
+  py38dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV=py38-dj41
+  py38dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV=py38-dj42
   py38djmaster:
     <<: *common
     docker:
       - image: circleci/python:3.8
         environment:
           TOXENV=py38-djmaster
+
   py39dj22:
     <<: *common
     docker:
@@ -126,12 +202,183 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV=py39-dj31
+  py39dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV=py39-dj32
+  py39dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV=py39-dj40
+  py39dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV=py39-dj41
+  py39dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV=py39-dj42
   py39djmaster:
     <<: *common
     docker:
       - image: circleci/python:3.9
         environment:
           TOXENV=py39-djmaster
+
+  py310dj22:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj22
+  py310dj30:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj30
+  py310dj31:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj31
+  py310dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj32
+  py310dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj40
+  py310dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj41
+  py310dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-dj42
+  py310djmaster:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV=py310-djmaster
+
+  py311dj22:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj22
+  py311dj30:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj30
+  py311dj31:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj31
+  py311dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj32
+  py311dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj40
+  py311dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj41
+  py311dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-dj42
+  py311djmaster:
+    <<: *common
+    docker:
+      - image: circleci/python:3.11
+        environment:
+          TOXENV=py311-djmaster
+
+  py312dj22:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj22
+  py312dj30:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj30
+  py312dj31:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj31
+  py312dj32:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj32
+  py312dj40:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj40
+  py312dj41:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj41
+  py312dj42:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-dj42
+  py312djmaster:
+    <<: *common
+    docker:
+      - image: circleci/python:3.12
+        environment:
+          TOXENV=py312-djmaster
 
 workflows:
   version: 2
@@ -141,17 +388,56 @@ workflows:
       - py36dj22
       - py36dj30
       - py36dj31
+      - py36dj32
+      - py36dj40
+      - py36dj41
+      - py36dj42
       - py36djmaster
       - py37dj22
       - py37dj30
       - py37dj31
+      - py37dj32
+      - py37dj40
+      - py37dj41
+      - py37dj42
       - py37djmaster
       - py38dj22
       - py38dj30
       - py38dj31
+      - py38dj32
+      - py38dj40
+      - py38dj41
+      - py38dj42
       - py38djmaster
       - py39dj22
       - py39dj30
       - py39dj31
+      - py39dj32
+      - py39dj40
+      - py39dj41
+      - py39dj42
       - py39djmaster
-
+      - py310dj22
+      - py310dj30
+      - py310dj31
+      - py310dj32
+      - py310dj40
+      - py310dj41
+      - py310dj42
+      - py310djmaster
+      - py311dj22
+      - py311dj30
+      - py311dj31
+      - py311dj32
+      - py311dj40
+      - py311dj41
+      - py311dj42
+      - py311djmaster
+      - py312dj22
+      - py312dj30
+      - py312dj31
+      - py312dj32
+      - py312dj40
+      - py312dj41
+      - py312dj42
+      - py312djmaster

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ wherever you have the model class, as well as any model instance.
 
 ```python
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from konst import Constant, ConstantGroup, Constants
 from konst.models.fields import (

--- a/konst/__init__.py
+++ b/konst/__init__.py
@@ -19,10 +19,10 @@ class Constant(object):
         self.label = label or self.id
 
     def __str__(self):
-        return u"{}".format(self.v)
+        return "{}".format(self.v)
 
     def __repr__(self):
-        return u"{} ({})".format(self.id, self.v)
+        return "{} ({})".format(self.id, self.v)
 
     def __resolve_other(self, other):
         if isinstance(other, Constant):
@@ -54,10 +54,10 @@ class Constant(object):
 
     def __getattr__(self, attr):
         """Allow dynamic lookup of equality and label."""
-        if attr == u"constants":
+        if attr == "constants":
             # https://nedbatchelder.com/blog/201010/surprising_getattr_recursion.html
             raise AttributeError(
-                u"`constants` not set on Constant so cannot check equality"
+                "`constants` not set on Constant so cannot check equality"
             )
         if attr in self.constants.by_id:
             return self.v == self.constants.by_id[attr].v
@@ -65,7 +65,7 @@ class Constant(object):
             return self.id in self.constants.groups[attr].constant_ids
         else:
             raise AttributeError(
-                u"'{}' object has no attribute '{}'".format(
+                "'{}' object has no attribute '{}'".format(
                     self.__class__.__name__, attr
                 )
             )
@@ -100,7 +100,7 @@ class Constants(object):
             elif isinstance(a, ConstantGroup):
                 self.groups[a.name] = a
             else:
-                raise ValueError(u"Received unexpected arg: {}".format(a))
+                raise ValueError("Received unexpected arg: {}".format(a))
 
         # setup useful precomputed lookups
         self.choices = [(k.v, k.label) for k in self.constants]
@@ -111,7 +111,7 @@ class Constants(object):
         for name, group in self.groups.items():
             if hasattr(self, name):
                 raise ValueError(
-                    u"ConstantGroup with name `{}` clashes with existing attribute.".format(
+                    "ConstantGroup with name `{}` clashes with existing attribute.".format(
                         name
                     )
                 )

--- a/konst/__init__.py
+++ b/konst/__init__.py
@@ -29,6 +29,13 @@ class Constant(object):
             return other.v
         return other
 
+    def __deepcopy__(self, memo):
+        copy = Constant(self.label, **{self.id: self.v})
+        # This does *not* deepcopy the constants object, since that is
+        # considered external
+        copy.constants = self.constants
+        return copy
+
     def __eq__(self, other):
         return self.v == self.__resolve_other(other)
 

--- a/konst/extras/drf/fields.py
+++ b/konst/extras/drf/fields.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.fields import Field
 

--- a/konst/models/fields.py
+++ b/konst/models/fields.py
@@ -60,7 +60,7 @@ class ConstantChoiceCharField(ConstantChoiceFieldMixin, CharField):
             return value
         if isinstance(value, Constant):
             return value
-        return self.constants.by_value.get(u"{}".format(value))
+        return self.constants.by_value.get("{}".format(value))
 
 
 __all__ = [ConstantChoiceField, ConstantChoiceCharField]

--- a/konst/tests/models.py
+++ b/konst/tests/models.py
@@ -9,7 +9,6 @@ from konst.models.fields import ConstantChoiceCharField, ConstantChoiceField
 
 
 class Apple(models.Model):
-
     purposes = Constants(
         Constant(cooking=0, label=_("Cook me!")),
         Constant(eating=1, label=_("Eat me!")),

--- a/konst/tests/models.py
+++ b/konst/tests/models.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from konst import Constant, ConstantGroup, Constants
 from konst.models.fields import ConstantChoiceCharField, ConstantChoiceField

--- a/konst/tests/tests.py
+++ b/konst/tests/tests.py
@@ -250,3 +250,22 @@ class DRFConstantChoiceFieldTestCase(TestCase):
         self.assertTrue(instance.colour.red)
         self.assertTrue(instance.purpose.eating)
         self.assertTrue(instance.purpose.culinary)
+
+
+class DeepCopyTestCase(TestCase):
+    fixtures = ["test_apples"]
+
+    def setUp(self):
+        self.purposes = DRFConstantChoiceField(Apple.purposes)
+        self.colours = DRFConstantChoiceField(Apple.colours)
+
+    def test_can_deepcopy(self):
+        original = Apple.objects.first()
+        other = copy.deepcopy(original)
+        self.assertTrue(original is not other)
+        self.assertTrue(original == other)
+        self.assertTrue(original.purpose == other.purpose)
+        self.assertTrue(original.purpose is not other.purpose)
+        self.assertTrue(original.colour is not other.colour)
+        self.assertTrue(original.purpose.constants is other.purpose.constants)
+        self.assertTrue(original.colour.constants is other.colour.constants)

--- a/konst/tests/tests.py
+++ b/konst/tests/tests.py
@@ -7,7 +7,7 @@ import sys
 
 from django.core.management import call_command
 from django.test import TestCase
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from rest_framework import serializers
 
@@ -97,12 +97,12 @@ class ConstantChoiceFieldTestCase(TestCase):
         self.assertTrue(instance.colour.green)
         self.assertTrue(instance.purpose.cooking)
 
-    def test_widget_force_text(self):
+    def test_widget_force_str(self):
         self.assertEqual(
-            force_text(self.instance.colour), u"{}".format(self.instance.colour.v)
+            force_str(self.instance.colour), u"{}".format(self.instance.colour.v)
         )
         self.assertEqual(
-            force_text(self.instance.purpose), u"{}".format(self.instance.purpose.v)
+            force_str(self.instance.purpose), u"{}".format(self.instance.purpose.v)
         )
 
     def test_getattr_equality_check(self):

--- a/konst/tests/tests.py
+++ b/konst/tests/tests.py
@@ -24,20 +24,20 @@ except ImportError:
 
 class ConstantTestCase(TestCase):
     def test_repr(self):
-        self.assertEqual(repr(Apple.purposes.cooking), u"cooking (0)")
-        self.assertEqual(repr(Apple.colours.red), u"red (FF0000)")
+        self.assertEqual(repr(Apple.purposes.cooking), "cooking (0)")
+        self.assertEqual(repr(Apple.colours.red), "red (FF0000)")
 
     def test_str(self):
-        self.assertEqual(str(Apple.purposes.cooking), u"0")
-        self.assertEqual(str(Apple.colours.red), u"FF0000")
+        self.assertEqual(str(Apple.purposes.cooking), "0")
+        self.assertEqual(str(Apple.colours.red), "FF0000")
 
     def test_comparison_with_int(self):
         self.assertEqual(Apple.purposes.cooking, 0)
         self.assertNotEqual(Apple.purposes.cooking, 1)
 
     def test_comparison_with_char(self):
-        self.assertEqual(Apple.colours.red, u"FF0000")
-        self.assertNotEqual(Apple.colours.red, u"FF0001")
+        self.assertEqual(Apple.colours.red, "FF0000")
+        self.assertNotEqual(Apple.colours.red, "FF0001")
 
     def test_comparison_with_constant(self):
         self.assertEqual(Apple.purposes.cooking, Apple.purposes.cooking)
@@ -75,7 +75,6 @@ class ConstantTestCase(TestCase):
 
 
 class ConstantChoiceFieldTestCase(TestCase):
-
     fixtures = ["test_apples"]
 
     def setUp(self):
@@ -83,7 +82,7 @@ class ConstantChoiceFieldTestCase(TestCase):
 
     def test_create_and_save(self):
         gala = Apple.objects.create(
-            name=u"Gala", colour=Apple.colours.red, purpose=Apple.purposes.eating
+            name="Gala", colour=Apple.colours.red, purpose=Apple.purposes.eating
         )
         self.assertTrue(isinstance(gala.colour, Constant))
         self.assertTrue(isinstance(gala.purpose, Constant))
@@ -99,10 +98,10 @@ class ConstantChoiceFieldTestCase(TestCase):
 
     def test_widget_force_str(self):
         self.assertEqual(
-            force_str(self.instance.colour), u"{}".format(self.instance.colour.v)
+            force_str(self.instance.colour), "{}".format(self.instance.colour.v)
         )
         self.assertEqual(
-            force_str(self.instance.purpose), u"{}".format(self.instance.purpose.v)
+            force_str(self.instance.purpose), "{}".format(self.instance.purpose.v)
         )
 
     def test_getattr_equality_check(self):
@@ -121,7 +120,7 @@ class ConstantChoiceFieldTestCase(TestCase):
         # if the grannysmith exists we"re good
         # as the tests have already loaded the fixture
         instance = Apple.objects.all().first()
-        self.assertEqual(instance.name, u"Granny Smith")
+        self.assertEqual(instance.name, "Granny Smith")
         self.assertTrue(instance.colour.green)
         self.assertTrue(instance.purpose.cooking)
 
@@ -133,7 +132,7 @@ class ConstantChoiceFieldTestCase(TestCase):
         dumped_data = json.loads(sys.stdout.getvalue())
         sys.stdout = sysout
         self.assertEqual(
-            dumped_data[0]["fields"]["colour"], u"{}".format(Apple.colours.green)
+            dumped_data[0]["fields"]["colour"], "{}".format(Apple.colours.green)
         )
 
     def test_copy(self):
@@ -172,7 +171,6 @@ class ConstantChoiceFieldTestCase(TestCase):
 
 
 class ConstantJSONSerializerTestCase(TestCase):
-
     # Can"t make it serializable by default .. use our custom encoder
     def test_json_serializable(self):
         data = {
@@ -183,7 +181,6 @@ class ConstantJSONSerializerTestCase(TestCase):
 
 
 class AppleSerializer(serializers.ModelSerializer):
-
     purpose = DRFConstantChoiceField(Apple.purposes)
     colour = DRFConstantChoiceField(Apple.colours)
 
@@ -193,7 +190,6 @@ class AppleSerializer(serializers.ModelSerializer):
 
 
 class DRFConstantChoiceFieldTestCase(TestCase):
-
     fixtures = ["test_apples"]
 
     def setUp(self):
@@ -202,13 +198,11 @@ class DRFConstantChoiceFieldTestCase(TestCase):
 
     def test_to_representation_int_backed(self):
         self.assertEqual(
-            self.purposes.to_representation(Apple.purposes.cooking), u"cooking"
+            self.purposes.to_representation(Apple.purposes.cooking), "cooking"
         )
 
     def test_to_representation_string_backed(self):
-        self.assertEqual(
-            self.colours.to_representation(Apple.colours.yellow), u"yellow"
-        )
+        self.assertEqual(self.colours.to_representation(Apple.colours.yellow), "yellow")
 
     def test_to_internal_value_int_backed(self):
         self.assertEqual(
@@ -221,12 +215,12 @@ class DRFConstantChoiceFieldTestCase(TestCase):
     def test_to_internal_value_not_a_valid_option_int_backed(self):
         with self.assertRaises(serializers.ValidationError) as e:
             self.colours.to_internal_value("purple")
-        self.assertEqual(e.exception.detail, [u'"purple" is not a valid choice.'])
+        self.assertEqual(e.exception.detail, ['"purple" is not a valid choice.'])
 
     def test_to_internal_value_not_a_valid_option_string_backed(self):
         with self.assertRaises(serializers.ValidationError) as e:
             self.purposes.to_internal_value("mincing")
-        self.assertEqual(e.exception.detail, [u'"mincing" is not a valid choice.'])
+        self.assertEqual(e.exception.detail, ['"mincing" is not a valid choice.'])
 
     def test_in_serializer_output(self):
         instance = Apple.objects.all().first()
@@ -243,8 +237,8 @@ class DRFConstantChoiceFieldTestCase(TestCase):
         self.assertEqual(
             serializer.errors,
             {
-                "colour": [u'"blue" is not a valid choice.'],
-                "purpose": [u'"dicing" is not a valid choice.'],
+                "colour": ['"blue" is not a valid choice.'],
+                "purpose": ['"dicing" is not a valid choice.'],
             },
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands =
     isort -rc --check-only --diff konst 
     black konst --check
 deps =
-    black == 20.8b1
+    black == 23.10.0
     flake8 == 3.8.4
     flake8-quotes == 3.2.0
     isort == 5.6.4

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ show_missing = True
 [tox]
 envlist =
     checkqa
-    py{36,37,38,39}-dj{22,30,31,master}
+    py{36,37,38,39,310,311,312}-dj{22,30,31,32,40,41,42,master}
 
 [testenv]
 passenv =
@@ -51,6 +51,14 @@ deps =
     dj30: djangorestframework>=3.10
     dj31: Django==3.1.*
     dj31: djangorestframework>=3.10
+    dj32: Django==3.2.*
+    dj32: djangorestframework>=3.10
+    dj40: Django==4.0.*
+    dj40: djangorestframework>=3.10
+    dj41: Django==4.1.*
+    dj41: djangorestframework>=3.10
+    dj42: Django==4.2.*
+    dj42: djangorestframework>=3.10
     djmaster: https://github.com/django/django/tarball/master
     djmaster: https://github.com/encode/django-rest-framework/tarball/master
 usedevelop = True


### PR DESCRIPTION
This collects some changes I had to make to make this work with newer Django versions.

The deepcopy commit was really needed to make django-konst work in my project's test suite again, the other commits are mostly to make django-konst's own test suite succeed again against newer Django versions.

I've added test configurations for all currently available Django and Python versions. Locally, tox could no longer test against Python 3.6, 3.7 and 3.8, I hope the online CI will still have these versions available. All the newly added Python and Django versions passed the test suite locally.